### PR TITLE
Add support to render hyperlinks in text nodes

### DIFF
--- a/settings/voiceflow.ts
+++ b/settings/voiceflow.ts
@@ -100,8 +100,24 @@ export class VFHelper {
   }
 
   public simplifyText(textPayload: VF_TEXT): SimpleText {
+    const { children } = textPayload.payload?.slate.content[0] || [];
+    const text: string[] = [];
+    children.forEach((child) => {
+      if (child.url) {
+        let label = child.url;
+        if (child.children) {
+          const [firstSubChild] = child.children;
+          if (firstSubChild.text) {
+            label = firstSubChild.text;
+          }
+        }
+        text.push(`<a href="${child.url}">${label}</a>`);
+      } else if (child.text) {
+        text.push(child.text);
+      }
+    });
     return {
-      text: textPayload.payload.message,
+      text: text.join(" "),
     };
   }
 
@@ -398,6 +414,17 @@ export type VF_TEXT<T = any> = {
       content: {
         children: {
           text: string;
+          url?: string;
+          children?: {
+            text: string;
+            color: {
+              r: number;
+              g: number;
+              b: number;
+              a: 1;
+            };
+            underline: boolean;
+          }[];
         }[];
       }[];
     };


### PR DESCRIPTION
- Add support to render hyperlinks in text nodes (not just "rich" components like cards/carousel/etc)

ex. 
<img width="306" alt="image" src="https://user-images.githubusercontent.com/1396559/222876859-72dc2b59-aa39-445e-931b-1c5f5d559bf5.png">

```json
{
  "type": "text",
  "payload": {
    "slate": {
      "id": "aaabbb",
      "content": [
        {
          "children": [
            {
              "text": "Special tezxt "
            },
            {
              "url": "https://www.allaboutfrogs.com",
              "type": "link",
              "children": [
                {
                  "text": "Sample Label here",
                  "color": {
                    "r": 93,
                    "g": 157,
                    "b": 245,
                    "a": 1
                  },
                  "underline": true
                }
              ]
            },
            {
              "text": ""
            }
          ]
        }
      ]
    },
    "message": "Sample Label here"
  }
}
```
